### PR TITLE
Add setops deployment actions

### DIFF
--- a/.github/workflows/setops_deployment_workflow.yml
+++ b/.github/workflows/setops_deployment_workflow.yml
@@ -29,6 +29,11 @@ on:
         required: false
         default: .
         type: string
+      build_cache_key_prefix:
+        description: The cache key used by docker buildx. The complete cache key is concatenated
+        required: false
+        default: app
+        type: string
     secrets:
       SETOPS_USER:
         required: true
@@ -56,6 +61,7 @@ jobs:
           setops_host: ${{ inputs.setops_host }}
           setops_organization: ${{ inputs.setops_organization }}
           build_context: ${{ inputs.build_context }}
+          build_cache_key_prefix: ${{ inputs.build_cache_key_prefix }}
 
   deploy:
     name: Setops Deployment

--- a/.github/workflows/setops_deployment_workflow.yml
+++ b/.github/workflows/setops_deployment_workflow.yml
@@ -1,0 +1,77 @@
+name: Setops Deployment
+on:
+  workflow_call:
+    inputs:
+      stages:
+        required: true
+        type: string
+      apps:
+        required: true
+        type: string
+      setops_organization:
+        description: The setops organization, defaults to zweitag
+        required: false
+        default: zweitag
+        type: string
+      setops_host:
+        description: The setops host, defaults to api.setops.co
+        required: false
+        default: api.setops.co
+        type: string
+      setops_project:
+        required: true
+        type: string
+      predeploy_command:
+        required: true
+        type: string
+    secrets:
+      SETOPS_USER:
+        required: true
+      SETOPS_PASSWORD:
+        required: true
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    outputs:
+      image_digest: ${{ steps.build_and_push_image.outputs.image_digest }}
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Build image and push it to setops image registry"
+        id: build_and_push_image
+        uses: zweitag/github-actions/setops_build_and_push_image@setops
+        with:
+          stages: ${{ inputs.stages }}
+          apps: ${{ inputs.apps }}
+          setops_username: ${{ secrets.SETOPS_USER }}
+          setops_password: ${{ secrets.SETOPS_PASSWORD }}
+          setops_project: ${{ inputs.setops_project }}
+          setops_host: ${{ inputs.setops_host }}
+          setops_organization: ${{ inputs.setops_organization }}
+
+  deploy:
+    name: Setops Deployment
+    strategy:
+      fail-fast: false
+      matrix:
+        stage: ${{ fromJson(inputs.stages) }}
+    concurrency: setops-deployment-${{ github.ref }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Deploy fillibri_web on setops"
+        id: deploy
+        uses: zweitag/github-actions/setops_deployment@setops
+        with:
+          stage: ${{ matrix.stage }}
+          apps: ${{ inputs.apps }}
+          setops_project: ${{ inputs.setops_project }}
+          setops_username: ${{ secrets.SETOPS_USER }}
+          setops_password: ${{ secrets.SETOPS_PASSWORD }}
+          image_digest: ${{ needs.build.outputs.image_digest }}
+          predeploy_command: ${{ inputs.predeploy_command }}
+          setops_organization: ${{ inputs.setops_organization }}

--- a/.github/workflows/setops_deployment_workflow.yml
+++ b/.github/workflows/setops_deployment_workflow.yml
@@ -24,6 +24,11 @@ on:
       predeploy_command:
         required: true
         type: string
+      build_context:
+        description: The build context / directory where the Dockerfile is located, defaults to '.'
+        required: false
+        default: .
+        type: string
     secrets:
       SETOPS_USER:
         required: true
@@ -50,6 +55,7 @@ jobs:
           setops_project: ${{ inputs.setops_project }}
           setops_host: ${{ inputs.setops_host }}
           setops_organization: ${{ inputs.setops_organization }}
+          build_context: ${{ inputs.build_context }}
 
   deploy:
     name: Setops Deployment

--- a/.github/workflows/setops_deployment_workflow.yml
+++ b/.github/workflows/setops_deployment_workflow.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v2
-      - name: "Deploy fillibri_web on setops"
+      - name: "Deploy project on setops"
         id: deploy
         uses: zweitag/github-actions/setops_deployment@setops
         with:

--- a/README_SETOPS.md
+++ b/README_SETOPS.md
@@ -1,0 +1,120 @@
+# Setops Deployment
+
+## Basic Usage
+
+The repository contains a complete [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) that can be integrated in ci pipelines to perform a complete setops deployment via
+
+```yaml
+name: Deployment
+on: push
+
+jobs:
+  setops_stages:
+    name: Detect setops stages based on the current branch
+    runs-on: ubuntu-latest
+    outputs:
+      stages: ${{ steps.stages.outputs.stages }}
+    if: github.ref == 'refs/heads/production' || github.ref == 'refs/heads/staging'
+    steps:
+      - name: "Detect setops stages based on the current branch"
+        id: stages
+        run: |
+          if [ "$GITHUB_REF" == "refs/heads/staging" ]; then 
+            echo '::set-output name=stages::["staging"]'
+          elif [ "$GITHUB_REF" == "refs/heads/production" ]; then 
+            echo '::set-output name=stages::["production"]'
+          else
+            echo "⚠️ Could not determine stages for $GITHUB_REF"
+            exit 1
+          fi
+
+  setops_deployment:
+    uses: zweitag/github-actions/.github/workflows/setops_deployment_workflow.yml@setops
+    with:
+      stages: ${{ needs.setops_stages.outputs.stages }}
+      apps: '["web", "clock", "worker"]'
+      setops_project: my_setops_project_name
+      predeploy_command: bin/rails db:migrate
+    secrets:
+      SETOPS_USER: ${{ secrets.SETOPS_USER }}
+      SETOPS_PASSWORD: ${{ secrets.SETOPS_PASSWORD }}
+```
+
+This workflow
+
+* Builds a docker image based on the `Dockerfile` in the project's root folder and pushes it to the setops registry
+* Deploys the image to every app configured in `apps`. If you configure more than one stage in `stages`, the workflow will deploy each stage in parallel
+
+CAUTION: The script assumes a configured healthcheck for *all* apps.
+
+See the [workflow file](.github/workflows/setops_deployment_workflow.yml) for all possible inputs
+
+## Building blocks
+
+The workflow consists of a small workflow file that calls two separate Github Actions which can also be included separately your Github Workflow.
+
+### Action: `setops_build_and_push_image` 
+
+The action builds the image and pushes it to the setops registry which all needed tags (one for each stage / app - combination). It also tries to provide a Docker cache.
+
+You can also use the action without the workflow:
+
+```yaml
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    outputs:
+      image_digest: ${{ steps.build_and_push_image.outputs.image_digest }}
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Build image and push it to setops image registry"
+        id: build_and_push_image
+        uses: zweitag/github-actions/setops_build_and_push_image@setops
+        with:
+          stages: ${{ needs.setops_stages.outputs.stages }}
+          apps: '["web", "clock", "worker"]'
+          setops_username: ${{ secrets.SETOPS_USER }}
+          setops_password: ${{ secrets.SETOPS_PASSWORD }}
+          setops_project: my_setops_project_name
+```
+
+See the [action file](setops_build_and_push_image/action.yml) for all possible inputs
+
+### Action: `setops_deployment` 
+
+The action
+
+* Creates releases for all configured apps
+* Runs the predeploy command within the first of the configured apps
+* Activates all releases
+* Waits until all releases are healthy
+
+You can also use the action without the workflow:
+
+```yaml
+ deploy:
+    name: Setops Deployment
+    strategy:
+      fail-fast: false
+    concurrency: setops-deployment-${{ github.ref }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Deploy project on setops"
+        id: deploy
+        uses: zweitag/github-actions/setops_deployment@setops
+        with:
+          stage: production
+          apps: ${{ inputs.apps }}
+          setops_project: my_setops_project_name
+          setops_username: ${{ secrets.SETOPS_USER }}
+          setops_password: ${{ secrets.SETOPS_PASSWORD }}
+          image_digest: ${{ needs.build.outputs.image_digest }}
+          predeploy_command: bin/rails db:migrate
+```
+
+See the [action file](setops_deployment/action.yml) for all possible inputs

--- a/setops_build_and_push_image/action.yml
+++ b/setops_build_and_push_image/action.yml
@@ -1,0 +1,95 @@
+name: "Build and push image to setops registry"
+description: "Builds the docker images and pushes it to the setops registry while creating a tag for each stage / app combination"
+
+inputs:
+  setops_organization:
+    description: The setops organization, defaults to zweitag
+    required: false
+    default: zweitag
+  setops_host:
+    description: The setops host, defaults to api.setops.co
+    required: false
+    default: api.setops.co
+  setops_project:
+    description: The setops project name
+    required: true
+  setops_username:
+    description: The setops username, usually obtained via secrets.SETOPS_USER
+    required: true
+  setops_password:
+    description: The setops password, usually obtained via secrets.SETOPS_PASSWORD
+    required: true
+  stages:
+    description: List of stages in JSON format, e.g. '["production" ,"demo"]'
+    required: true
+  apps:
+    description: List of apps in JSON format, e.g. '["web", "clock", "worker"]'
+    required: true
+
+outputs:
+  image_digest:
+    value: ${{ steps.build_app.outputs.digest }}
+    description: The digest of the image that can be referred to when creating releases
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Detect setops target tag_names"
+      id: build_tag_names
+      run: |
+        declare -a tag_names
+        for stage in $(echo '${{ inputs.stages }}' | jq -r '.[]'); do
+          for app in $(echo '${{ inputs.apps }}' | jq -r '.[]'); do
+            tag_names+=("${{ inputs.setops_host }}/${{ inputs.setops_organization }}/${{ inputs.setops_project }}/$stage/$app:latest")
+          done
+        done
+
+        # https://stackoverflow.com/a/2317171
+        concatenated_tag_names=$(printf ",%s" "${tag_names[@]}")
+        concatenated_tag_names=${concatenated_tag_names:1}
+
+        echo "::set-output name=concatenated_tag_names::$concatenated_tag_names"
+      shell: bash
+    - name: "Set up Docker Buildx"
+      uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: "Install Setops"
+      uses: setopsco/setup-setops@v3
+      with:
+        setops_organization: ${{ inputs.setops_organization }}
+        setops_username: ${{ inputs.setops_username }}
+        setops_password: ${{ inputs.setops_password }}
+    - name: "Login to SetOps registry"
+      run: |
+        LOGIN_COMMAND=$(setops registry:login | grep printf)
+        eval $LOGIN_COMMAND
+      shell: bash
+    - name: "Set git revision"
+      run: |
+        echo "commit_sha=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+      shell: bash
+    - name: Build and push app
+      id: build_app
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.build_tag_names.outputs.concatenated_tag_names }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+        no-cache: ${{ github.event_name == 'schedule' }}
+        build-args: COMMIT_SHA=${{env.commit_sha}}
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      shell: bash

--- a/setops_build_and_push_image/action.yml
+++ b/setops_build_and_push_image/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: The build context / directory where the Dockerfile is located, defaults to '.'
     required: false
     default: .
+  build_cache_key_prefix:
+    description: The cache key used by docker buildx. The complete cache key is concatenated
+    required: false
+    default: app
 
 outputs:
   image_digest:
@@ -60,9 +64,9 @@ runs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ inputs.build_cache_key_prefix }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-buildx-
+          ${{ runner.os }}-buildx-${{ inputs.build_cache_key_prefix }}-
     - name: "Install Setops"
       uses: setopsco/setup-setops@v3
       with:

--- a/setops_build_and_push_image/action.yml
+++ b/setops_build_and_push_image/action.yml
@@ -25,6 +25,10 @@ inputs:
   apps:
     description: List of apps in JSON format, e.g. '["web", "clock", "worker"]'
     required: true
+  build_context:
+    description: The build context / directory where the Dockerfile is located, defaults to '.'
+    required: false
+    default: .
 
 outputs:
   image_digest:
@@ -78,7 +82,7 @@ runs:
       id: build_app
       uses: docker/build-push-action@v2
       with:
-        context: .
+        context: ${{ inputs.build_context }}
         push: true
         tags: ${{ steps.build_tag_names.outputs.concatenated_tag_names }}
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/setops_deployment/action.yml
+++ b/setops_deployment/action.yml
@@ -1,0 +1,90 @@
+name: "Setops deployment"
+description: "Creates and activates releases for multiple apps within a setops stage, performs a predeploy command, waits for the releases to become healthy"
+
+inputs:
+  setops_organization:
+    description: The setops organization, defaults to zweitag
+    required: false
+    default: zweitag
+  setops_project:
+    description: The setops project name
+    required: true
+  setops_username:
+    description: The setops username, usually obtained via secrets.SETOPS_USER
+    required: true
+  setops_password:
+    description: The setops password, usually obtained via secrets.SETOPS_PASSWORD
+    required: true
+  image_digest:
+    description: The image digest that was returned when pushing the image to the setops registry
+    required: true
+  stage:
+    description: The setops stage for the deployment, e.g. production
+    required: true
+  apps:
+    description: List of apps in JSON format, e.g. '["web", "clock", "worker"]'
+    required: true
+  number_of_retries_to_wait_for_successful_deployment:
+    description: Max. number of times to wait for a succesful deployment (we sleep for 5 seconds between tries, so 12 equals 1 minute)
+    required: false
+    default: "24"
+  predeploy_command:
+    description: A predeploy command to be run before activating the releases, e.g. for migrating the database
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: "Install Setops"
+      uses: setopsco/setup-setops@v3
+      with:
+        setops_organization: ${{ inputs.setops_organization }}
+        setops_username: ${{ inputs.setops_username }}
+        setops_password: ${{ inputs.setops_password }}
+    - name: "Setops deployment"
+      run: |
+        shopt -s expand_aliases 
+        alias sos='setops -p ${{ inputs.setops_project }} -s ${{ inputs.stage }}'
+
+        declare -a apps
+        for app in $(echo '${{ inputs.apps }}' | jq -r '.[]'); do
+          apps+=($app)
+        done
+
+        sos changeset:discard || true
+
+        declare -A apps_with_release_id
+
+        for app in ${apps[@]}; do
+          apps_with_release_id[$app]=$(sos --app $app release:create ${{ inputs.image_digest }} | grep -o 'ReleaseID.*' | grep -o '[0-9].*')
+        done
+
+        echo "Changeset for creating releases"
+        sos changeset:commit
+
+        echo "Run predeploy command"
+        first_app=${apps[0]}
+        release_id_of_first_app=${apps_with_release_id[$first_app]}
+        sos --app $first_app task:run --debug --release $release_id_of_first_app -- bash -c "${{ inputs.predeploy_command }} && echo 'SETOPS_SUCCESS'" | tee /dev/stderr | grep "SETOPS_SUCCESS" > /dev/null
+
+        for app in "${apps[@]}"; do
+          release_id=${apps_with_release_id[$app]}
+          sos --app $app release:activate $release_id
+        done
+
+        echo "Changeset for activating releases"
+        sos changeset:commit
+
+        echo "Waiting for successful releases"
+        max_times=${{ inputs.number_of_retries_to_wait_for_successful_deployment }}
+        for app in "${apps[@]}"; do
+          release_id=${apps_with_release_id[$app]}
+
+          for i in $(seq 1 $max_times); do 
+            sleep 5
+            if sos app:ps $app | grep -w -E "$release_id.*HEALTHY"; then break; fi
+            echo "Continue waiting for $app release $release_id"
+
+            if [ $i = $max_times ]; then exit 1; fi
+          done
+        done
+      shell: bash


### PR DESCRIPTION
See [the contained README](https://github.com/zweitag/github-actions/blob/setops/README_SETOPS.md) for details

- [x] Clarify if we need to support to refresh the Docker Cache
- [x] Enable Runs without a predeploy command
- [ ] Add Output if workflow was successful or not