### PR TITLE
Remove special handling "no cache for scheduled builds"

### DIFF
--- a/setops_build_and_push_image/action.yml
+++ b/setops_build_and_push_image/action.yml
@@ -98,7 +98,6 @@ runs:
         tags: ${{ steps.build_tag_names.outputs.concatenated_tag_names }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
-        no-cache: ${{ github.event_name == 'schedule' }}
         build-args: COMMIT_SHA=${{env.commit_sha}}
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252


### PR DESCRIPTION
# Goal
Remove special handling for `setops_build_and_push_image` action that triggers `no-cache` for scheduled builds. The cache is invalidated each day by a date prefix in the cache key, no need to have scheduled builds for a clean build anymore.